### PR TITLE
Only run Dep Graph on Master Push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
+      if: github.event_name != 'pull_request' # Should only update When actually in use
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
       with:
         directory: backend/focusflow


### PR DESCRIPTION
Ich hoffe das behebt die probleme mit dependabot.
Von dem was ich in anderen repos sehe sollte das nur für main laufen (macht ja auch wenig sin die Dependencies von ner PR zu speichern )
